### PR TITLE
UI design uplift and typography

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,12 @@
 <!doctype html>
 <html lang="en">
   <head>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Figtree:ital,wght@0,300..900;1,300..900&display=swap"
+      rel="stylesheet"
+    />
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,10 +9,12 @@ import { movieToScheduleEntry } from "@/lib/movieUtils";
 import { Button } from "@/components/ui/button";
 import { Toaster } from "@/components/ui/sonner";
 import { toast } from "sonner";
-import { ExitIcon } from "@radix-ui/react-icons";
+import { ExitIcon, SunIcon, MoonIcon } from "@radix-ui/react-icons";
+import { useThemeContext } from "@/contexts/ThemeContext";
 
 function App() {
   const { isLoggedIn, user, isLoading, handleLogout } = useAuthContext();
+  const { theme, toggleTheme } = useThemeContext();
   const [schedule, setSchedule] = useState<ScheduleEntry[]>([]);
 
   const handleAddToSchedule = useCallback((movie: Movie) => {
@@ -47,8 +49,8 @@ function App() {
 
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-gray-950 via-gray-900 to-gray-950 flex items-center justify-center">
-        <div className="text-gray-400 text-lg">Loading...</div>
+      <div className="min-h-screen bg-background flex items-center justify-center">
+        <div className="text-muted-foreground text-lg">Loading...</div>
       </div>
     );
   }
@@ -56,26 +58,35 @@ function App() {
   if (!isLoggedIn) {
     return (
       <>
-        <Toaster />
+        <Toaster theme={theme} />
         <LoginPage />
       </>
     );
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-gray-950 via-gray-900 to-gray-950 flex flex-col">
-      <Toaster />
+    <div className="min-h-screen bg-background flex flex-col">
+      <Toaster theme={theme} />
 
-      <header className="py-8 max-w-4xl mx-auto px-6 w-full">
-        <div className="flex items-center justify-between">
-          <h1 className="text-3xl font-bold text-white">Movie Club Schedule</h1>
+      <header className="bg-[var(--color-header)] py-6 px-6 shadow-lg">
+        <div className="max-w-4xl mx-auto flex items-center justify-between">
+          <h1 className="text-3xl font-bold uppercase tracking-wide text-[var(--color-header-foreground)]">Movie Club Schedule</h1>
           <div className="flex items-center gap-4">
-            <span className="text-sm text-gray-400">{user?.email}</span>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={toggleTheme}
+              className="text-[var(--color-header-muted)] hover:text-[var(--color-header-foreground)] hover:bg-black/10 h-8 w-8"
+              aria-label={theme === "dark" ? "Switch to light mode" : "Switch to dark mode"}
+            >
+              {theme === "dark" ? <SunIcon className="h-4 w-4" /> : <MoonIcon className="h-4 w-4" />}
+            </Button>
+            <span className="text-sm text-[var(--color-header-muted)]">{user?.email}</span>
             <Button
               variant="ghost"
               size="sm"
               onClick={handleLogout}
-              className="text-gray-400 hover:text-white"
+              className="text-[var(--color-header-muted)] hover:text-[var(--color-header-foreground)] hover:bg-black/10"
             >
               <ExitIcon className="h-4 w-4 mr-2" />
               Sign out
@@ -84,17 +95,17 @@ function App() {
         </div>
       </header>
 
-      <main className="flex-1 flex flex-col items-center px-6 pb-12">
+      <main className="flex-1 flex flex-col items-center px-6 pt-10 pb-12">
         <div className="w-full max-w-3xl space-y-12">
           <MovieSearch onAddToSchedule={handleAddToSchedule} />
 
           {schedule.length > 0 && (
-            <section className="bg-gray-900/60 backdrop-blur-sm rounded-2xl border border-gray-800 p-8 shadow-2xl">
+            <section className="bg-card rounded-2xl border border-border p-8 shadow-md">
               <div className="flex items-center justify-between mb-6">
-                <h2 className="text-2xl font-semibold text-white">
+                <h2 className="text-2xl font-bold text-foreground">
                   Upcoming Schedule
                 </h2>
-                <span className="text-sm text-gray-400 bg-gray-800/80 px-4 py-2 rounded-full border border-gray-700">
+                <span className="text-sm text-muted-foreground bg-secondary px-4 py-2 rounded-full border border-border">
                   {schedule.length} {schedule.length === 1 ? "movie" : "movies"}
                 </span>
               </div>

--- a/src/components/ErrorFallback.tsx
+++ b/src/components/ErrorFallback.tsx
@@ -3,10 +3,10 @@ import { Button } from "@/components/ui/button";
 
 export function ErrorFallback({ error, resetErrorBoundary }: FallbackProps) {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-gray-950 via-gray-900 to-gray-950 flex items-center justify-center p-6">
-      <div className="bg-gray-900/60 backdrop-blur-sm rounded-2xl border border-red-500/50 p-8 shadow-2xl max-w-md w-full text-center">
+    <div className="min-h-screen bg-background flex items-center justify-center p-6">
+      <div className="bg-card rounded-2xl border border-destructive/50 p-8 shadow-2xl max-w-md w-full text-center">
         <div className="text-4xl mb-4">Something went wrong</div>
-        <p className="text-gray-400 mb-6">
+        <p className="text-muted-foreground mb-6">
           {error.message || "An unexpected error occurred"}
         </p>
         <Button onClick={resetErrorBoundary} variant="destructive">

--- a/src/components/LoginPage.tsx
+++ b/src/components/LoginPage.tsx
@@ -11,6 +11,8 @@ import {
 } from "@radix-ui/react-icons";
 import { SunIcon, MoonIcon } from "@radix-ui/react-icons";
 import { toast } from "sonner";
+import { useThemeContext } from "@/contexts/ThemeContext";
+
 type ForgotStep = null | "request" | "confirm";
 
 export default function LoginPage() {
@@ -27,6 +29,8 @@ export default function LoginPage() {
   const [confirmPassword, setConfirmPassword] = useState("");
   const [showPassword, setShowPassword] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const { theme, toggleTheme } = useThemeContext();
+
   const [forgotStep, setForgotStep] = useState<ForgotStep>(null);
   const [forgotEmail, setForgotEmail] = useState("");
   const [resetCode, setResetCode] = useState("");
@@ -124,9 +128,24 @@ export default function LoginPage() {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-gray-950 via-gray-900 to-gray-950 flex items-center justify-center px-6">
+    <div className="min-h-screen bg-background flex items-center justify-center px-6 relative">
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={toggleTheme}
+        className="absolute top-4 right-4 text-muted-foreground hover:text-foreground h-8 w-8"
+        aria-label={
+          theme === "dark" ? "Switch to light mode" : "Switch to dark mode"
+        }
+      >
+        {theme === "dark" ? (
+          <SunIcon className="h-4 w-4" />
+        ) : (
+          <MoonIcon className="h-4 w-4" />
+        )}
+      </Button>
       <div className="w-full max-w-md">
-
+        <div className="bg-card rounded-2xl border border-border p-8 shadow-2xl">
           {/* Back button for forgot password steps */}
           {forgotStep && (
             <button
@@ -143,7 +162,7 @@ export default function LoginPage() {
           )}
 
           <div className="text-center mb-8">
-            <h1 className="text-3xl font-bold text-white mb-2">
+            <h1 className="text-3xl font-bold text-foreground uppercase tracking-wide mb-2">
               {getHeading()}
             </h1>
             <p className="text-muted-foreground">{getSubtext()}</p>
@@ -246,7 +265,9 @@ export default function LoginPage() {
                     type="button"
                     onClick={() => setShowPassword(!showPassword)}
                     className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
-                    aria-label={showPassword ? "Hide password" : "Show password"}
+                    aria-label={
+                      showPassword ? "Hide password" : "Show password"
+                    }
                   >
                     {showPassword ? (
                       <EyeClosedIcon className="h-5 w-5" />
@@ -257,7 +278,10 @@ export default function LoginPage() {
                 </div>
               </div>
               <div className="space-y-2">
-                <Label htmlFor="resetConfirmPassword" className="text-foreground">
+                <Label
+                  htmlFor="resetConfirmPassword"
+                  className="text-foreground"
+                >
                   Confirm New Password
                 </Label>
                 <div className="relative">
@@ -279,7 +303,9 @@ export default function LoginPage() {
                     type="button"
                     onClick={() => setShowPassword(!showPassword)}
                     className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
-                    aria-label={showPassword ? "Hide password" : "Show password"}
+                    aria-label={
+                      showPassword ? "Hide password" : "Show password"
+                    }
                   >
                     {showPassword ? (
                       <EyeClosedIcon className="h-5 w-5" />
@@ -331,7 +357,9 @@ export default function LoginPage() {
                     type="button"
                     onClick={() => setShowPassword(!showPassword)}
                     className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
-                    aria-label={showPassword ? "Hide password" : "Show password"}
+                    aria-label={
+                      showPassword ? "Hide password" : "Show password"
+                    }
                   >
                     {showPassword ? (
                       <EyeClosedIcon className="h-5 w-5" />
@@ -364,7 +392,9 @@ export default function LoginPage() {
                     type="button"
                     onClick={() => setShowPassword(!showPassword)}
                     className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
-                    aria-label={showPassword ? "Hide password" : "Show password"}
+                    aria-label={
+                      showPassword ? "Hide password" : "Show password"
+                    }
                   >
                     {showPassword ? (
                       <EyeClosedIcon className="h-5 w-5" />
@@ -434,7 +464,9 @@ export default function LoginPage() {
                     type="button"
                     onClick={() => setShowPassword(!showPassword)}
                     className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
-                    aria-label={showPassword ? "Hide password" : "Show password"}
+                    aria-label={
+                      showPassword ? "Hide password" : "Show password"
+                    }
                   >
                     {showPassword ? (
                       <EyeClosedIcon className="h-5 w-5" />
@@ -466,7 +498,6 @@ export default function LoginPage() {
               </div>
             </form>
           )}
-
         </div>
       </div>
     </div>

--- a/src/components/MoviePoster.tsx
+++ b/src/components/MoviePoster.tsx
@@ -23,7 +23,7 @@ export function MoviePoster({
     />
   ) : (
     <div
-      className={`${className} bg-gray-700 rounded flex items-center justify-center text-gray-500 text-xs`}
+      className={`${className} bg-secondary rounded flex items-center justify-center text-muted-foreground text-xs`}
     >
       🎬
     </div>

--- a/src/components/MovieSearch.tsx
+++ b/src/components/MovieSearch.tsx
@@ -23,14 +23,14 @@ const MovieResultItem = memo(
       key={movie.id}
       value={`${movie.id}-${movie.title}`}
       onSelect={onSelect}
-      className="flex items-center gap-4 p-3 cursor-pointer rounded-lg data-[selected=true]:bg-blue-600/30 aria-selected:bg-blue-600/30 transition-colors"
+      className="flex items-center gap-4 p-3 cursor-pointer rounded-lg data-[selected=true]:bg-accent aria-selected:bg-accent transition-colors"
     >
       <MoviePoster path={movie.poster_path} title={movie.title} />
       <div className="flex-1 min-w-0">
-        <h3 className="font-medium text-white truncate text-base">
+        <h3 className="font-medium text-foreground truncate text-base">
           {movie.title}
         </h3>
-        <p className="text-sm text-gray-400">
+        <p className="text-sm text-muted-foreground">
           {getMovieYear(movie.release_date)}
         </p>
       </div>
@@ -111,7 +111,7 @@ export default function MovieSearch({ onAddToSchedule }: MovieSearchProps) {
   return (
     <>
       <Command
-        className="bg-gray-800 rounded-2xl shadow-2xl border border-gray-700/50 [&_[cmdk-input-wrapper]]:border-none"
+        className="bg-card rounded-2xl shadow-md border border-border [&_[cmdk-input-wrapper]]:border-none"
         shouldFilter={false}
       >
         <div className="relative">
@@ -119,20 +119,20 @@ export default function MovieSearch({ onAddToSchedule }: MovieSearchProps) {
             placeholder="What are we watching next week?"
             value={searchQuery}
             onValueChange={setSearchQuery}
-            className="text-xl pl-0 pr-4 py-6 h-auto border-none text-white placeholder:text-gray-500 font-light"
+            className="text-xl pl-0 pr-4 py-6 h-auto border-none text-foreground placeholder:text-muted-foreground font-light"
           />
 
           {loading && (
             <div className="absolute right-5 top-1/2 -translate-y-1/2">
-              <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-blue-500" />
+              <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-foreground" />
             </div>
           )}
         </div>
 
         {(movies.length > 0 || showEmptyMessage) && (
-          <CommandList className="mt-3 bg-gray-800 border border-gray-700/50 rounded-2xl shadow-2xl max-h-96 overflow-y-auto will-change-scroll [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-thumb]:bg-gray-600 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-track]:bg-transparent">
+          <CommandList className="mt-3 bg-card border border-border rounded-2xl shadow-md max-h-96 overflow-y-auto will-change-scroll [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-thumb]:bg-border [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-track]:bg-transparent">
             {showEmptyMessage && movies.length === 0 && (
-              <CommandEmpty className="py-6 text-center text-gray-400 text-base">
+              <CommandEmpty className="py-6 text-center text-muted-foreground text-base">
                 No movies found. Try a different search.
               </CommandEmpty>
             )}
@@ -152,7 +152,7 @@ export default function MovieSearch({ onAddToSchedule }: MovieSearchProps) {
       </Command>
 
       {error && (
-        <div className="mt-4 bg-red-900/20 backdrop-blur-sm border border-red-500/50 text-red-300 px-4 py-3 rounded-xl text-sm shadow-lg">
+        <div className="mt-4 bg-destructive/10 border border-destructive/20 text-destructive px-4 py-3 rounded-xl text-sm shadow-lg">
           {error}
         </div>
       )}

--- a/src/components/Schedule.tsx
+++ b/src/components/Schedule.tsx
@@ -38,22 +38,22 @@ const ScheduleItem = memo(({
     onDrop={onDrop}
     className={`
       flex items-center gap-4 p-4 transition-all cursor-move
-      ${isDragging ? "opacity-50 border-blue-500" : "border-gray-700"}
-      ${isDropTarget ? "bg-blue-900/20 border-blue-500" : "bg-gray-800/50"}
-      hover:bg-gray-700/50 hover:border-gray-600
+      ${isDragging ? "opacity-50 border-foreground" : "border-border"}
+      ${isDropTarget ? "bg-accent border-foreground" : "bg-card"}
+      hover:bg-accent/50 hover:border-border
     `}
   >
-    <div className="text-gray-500 font-mono text-sm w-8 text-center shrink-0">
+    <div className="text-muted-foreground font-mono text-sm w-8 text-center shrink-0">
       #{entry.order}
     </div>
 
     <MoviePoster path={entry.poster_path} title={entry.title} />
 
     <div className="flex-1 min-w-0">
-      <h3 className="font-medium text-white truncate text-sm mb-1">
+      <h3 className="font-medium text-foreground truncate text-sm mb-1">
         {entry.title}
       </h3>
-      <p className="text-xs text-gray-400">
+      <p className="text-xs text-muted-foreground">
         {getMovieYear(entry.release_date)}
       </p>
     </div>
@@ -106,7 +106,7 @@ export default function Schedule({
 
   if (schedule.length === 0) {
     return (
-      <Card className="text-center py-12 text-gray-400 bg-gray-800/30 border-2 border-dashed border-gray-700">
+      <Card className="text-center py-12 text-muted-foreground bg-secondary/30 border-2 border-dashed border-border">
         <p className="text-lg mb-2">No movies scheduled</p>
         <p className="text-sm">Search and add movies to your schedule</p>
       </Card>

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -11,10 +11,10 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-md border border-gray-700 bg-gray-800 px-3 py-2 text-sm text-white placeholder:text-gray-500",
-          "focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent",
+          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground",
+          "focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent",
           "disabled:cursor-not-allowed disabled:opacity-50",
-          "aria-[invalid=true]:border-red-500 aria-[invalid=true]:ring-red-500",
+          "aria-[invalid=true]:border-destructive aria-[invalid=true]:ring-destructive",
           className
         )}
         ref={ref}

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,29 +1,26 @@
-import { Toaster as Sonner } from "sonner"
+import { Toaster as Sonner } from "sonner";
 
-type ToasterProps = React.ComponentProps<typeof Sonner>
+type ToasterProps = React.ComponentProps<typeof Sonner>;
 
 const Toaster = ({ ...props }: ToasterProps) => {
   return (
     <Sonner
-      theme="dark"
-      position="top-right"
+      position="top-center"
       className="toaster group"
       toastOptions={{
         classNames: {
           toast:
-            "group toast group-[.toaster]:bg-gray-800 group-[.toaster]:text-white group-[.toaster]:border-gray-700 group-[.toaster]:shadow-lg",
-          description: "group-[.toast]:text-gray-400",
-          actionButton:
-            "group-[.toast]:bg-blue-600 group-[.toast]:text-white",
+            "group toast group-[.toaster]:bg-card group-[.toaster]:text-card-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg",
+          description: "group-[.toast]:text-muted-foreground",
+          actionButton: "group-[.toast]:bg-primary group-[.toast]:text-primary-foreground",
           cancelButton:
-            "group-[.toast]:bg-gray-700 group-[.toast]:text-gray-300",
-          success:
-            "!bg-green-900/80 !border-green-700 !text-green-50",
+            "group-[.toast]:bg-secondary group-[.toast]:text-secondary-foreground",
+          success: "!bg-green-900/80 !border-green-700 !text-green-50",
         },
       }}
       {...props}
     />
-  )
-}
+  );
+};
 
-export { Toaster }
+export { Toaster };

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -1,0 +1,17 @@
+import { createContext, useContext, type ReactNode } from "react";
+import { useTheme } from "@/hooks/useTheme";
+
+type ThemeContextValue = ReturnType<typeof useTheme>;
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const value = useTheme();
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export function useThemeContext() {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error("useThemeContext must be used within ThemeProvider");
+  return ctx;
+}

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,0 +1,24 @@
+import { useState, useEffect, useCallback } from "react";
+
+type Theme = "light" | "dark";
+
+export function useTheme() {
+  const [theme, setThemeState] = useState<Theme>(() => {
+    const stored = localStorage.getItem("theme");
+    if (stored === "light" || stored === "dark") return stored;
+    return window.matchMedia("(prefers-color-scheme: dark)").matches
+      ? "dark"
+      : "light";
+  });
+
+  useEffect(() => {
+    document.documentElement.classList.toggle("dark", theme === "dark");
+    localStorage.setItem("theme", theme);
+  }, [theme]);
+
+  const toggleTheme = useCallback(() => {
+    setThemeState((prev) => (prev === "light" ? "dark" : "light"));
+  }, []);
+
+  return { theme, toggleTheme };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,37 +1,83 @@
 @import "tailwindcss";
 
+@custom-variant dark (&:where(.dark, .dark *));
+
 @theme {
-  /* Dark theme colors */
-  --color-background: #0a0a0a;
-  --color-foreground: #fafafa;
-  --color-card: #1a1a1a;
-  --color-card-foreground: #fafafa;
-  --color-popover: #0a0a0a;
-  --color-popover-foreground: #fafafa;
-  --color-primary: #3b82f6;
-  --color-primary-foreground: #f8fafc;
-  --color-secondary: #1e293b;
-  --color-secondary-foreground: #f1f5f9;
-  --color-muted: #1e293b;
-  --color-muted-foreground: #94a3b8;
-  --color-accent: #1e293b;
-  --color-accent-foreground: #f1f5f9;
-  --color-destructive: #7f1d1d;
-  --color-destructive-foreground: #fef2f2;
-  --color-border: #27272a;
-  --color-input: #27272a;
-  --color-ring: #3b82f6;
+  /* Typography */
+  --font-sans: "Figtree", sans-serif;
+
+  /* Brand colors */
+  --color-brand-red: #E3394C;
+  --color-brand-blue: #164180;
+  --color-brand-coral: #E55C6E;
+  --color-brand-cream: #F1EEE9;
+  --color-brand-silver: #BABBC5;
+
+  /* Light theme (default) */
+  --color-background: #ffffff;
+  --color-foreground: #2a2a2a;
+  --color-card: #F6F6F6;
+  --color-card-foreground: #2a2a2a;
+  --color-popover: #F6F6F6;
+  --color-popover-foreground: #2a2a2a;
+  --color-primary: #E55C6E;
+  --color-primary-foreground: #ffffff;
+  --color-secondary: #BABBC5;
+  --color-secondary-foreground: #2a2a2a;
+  --color-muted: #BABBC5;
+  --color-muted-foreground: #6b6b6b;
+  --color-accent: #E8E4DE;
+  --color-accent-foreground: #2a2a2a;
+  --color-destructive: #dc2626;
+  --color-destructive-foreground: #ffffff;
+  --color-border: #d5d0c9;
+  --color-input: #d5d0c9;
+  --color-ring: #E55C6E;
+
+  /* Header */
+  --color-header: #F6F6F6;
+  --color-header-foreground: #2a2a2a;
+  --color-header-muted: rgba(42, 42, 42, 0.5);
 
   --radius-lg: 0.5rem;
   --radius-md: calc(0.5rem - 2px);
   --radius-sm: calc(0.5rem - 4px);
 }
 
-:root {
-  font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
-  font-weight: 400;
+/* Dark theme - inverted light */
+.dark {
+  --color-background: #1a1a1a;
+  --color-foreground: #ffffff;
+  --color-card: #242424;
+  --color-card-foreground: #ffffff;
+  --color-popover: #242424;
+  --color-popover-foreground: #ffffff;
+  --color-primary: #E55C6E;
+  --color-primary-foreground: #ffffff;
+  --color-secondary: #333333;
+  --color-secondary-foreground: #ffffff;
+  --color-muted: #333333;
+  --color-muted-foreground: rgba(255, 255, 255, 0.5);
+  --color-accent: #2e2e2e;
+  --color-accent-foreground: #ffffff;
+  --color-destructive: #dc2626;
+  --color-destructive-foreground: #ffffff;
+  --color-border: rgba(255, 255, 255, 0.1);
+  --color-input: rgba(255, 255, 255, 0.1);
+  --color-ring: #E55C6E;
+
+  --color-header: #242424;
+  --color-header-foreground: #ffffff;
+  --color-header-muted: rgba(255, 255, 255, 0.5);
+
   color-scheme: dark;
+}
+
+:root {
+  font-family: "Figtree", sans-serif;
+  font-weight: 400;
+  line-height: 1.5;
+  color-scheme: light;
   background-color: var(--color-background);
   color: var(--color-foreground);
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,7 @@ import { Amplify } from "aws-amplify";
 import { ErrorBoundary } from "react-error-boundary";
 import { ErrorFallback } from "@/components/ErrorFallback";
 import { AuthProvider } from "@/contexts/AuthContext";
+import { ThemeProvider } from "@/contexts/ThemeContext";
 import "./index.css";
 import App from "./App.tsx";
 
@@ -30,9 +31,11 @@ Amplify.configure({
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <ErrorBoundary FallbackComponent={ErrorFallback}>
-      <AuthProvider>
-        <App />
-      </AuthProvider>
+      <ThemeProvider>
+        <AuthProvider>
+          <App />
+        </AuthProvider>
+      </ThemeProvider>
     </ErrorBoundary>
   </StrictMode>,
 );


### PR DESCRIPTION
 ## Overview

  Visual redesign and UX uplift replacing the previous dark-only hardcoded
  colour scheme with a proper light/dark theme system, a brand colour
  palette, and a new typeface. All colour classes are now semantic design
  tokens, making future theme changes a single-file edit in `index.css`.

  ## Changes

  ### Theme system
  - New `useTheme` hook — persists preference to `localStorage`, falls back
    to `prefers-color-scheme` on first visit
  - Dark mode toggle button added to both the header and the login page
  - Full light and dark CSS variable sets defined in `index.css` using
    Tailwind's `@custom-variant dark`

  ### Design tokens & colour palette
  - Brand colours introduced: red (`#E3394C`), blue (`#164180`), coral
    (`#E55C6E`), cream (`#F1EEE9`), silver (`#BABBC5`)
  - All hardcoded `gray-*`, `blue-*`, and `red-*` Tailwind classes replaced
    with semantic tokens (`bg-card`, `text-foreground`, `border-border`,
    `text-muted-foreground`, `bg-destructive`, etc.) across `App.tsx`,
    `LoginPage.tsx`, `MovieSearch.tsx`, `Schedule.tsx`, `MoviePoster.tsx`,
    `ErrorFallback.tsx`, and `input.tsx`

  ### Typography
  - Global font switched to **Figtree** via Google Fonts

  ### Polish
  - Toast notifications repositioned from `top-right` to `top-center`
  - Login card gets explicit border and shadow
  - Header gets a solid background with shadow
  

### See Screenshots Below: 
 <img width="1461" height="828" alt="image" src="https://github.com/user-attachments/assets/8a9e8886-8c18-4d33-b88f-1daa08761486" />
<img width="1457" height="764" alt="image" src="https://github.com/user-attachments/assets/1e5d190c-689e-4a4d-85c3-b460013bc8ae" />
<img width="1452" height="761" alt="image" src="https://github.com/user-attachments/assets/4a85902f-7738-4fc3-a9c6-3cabd77a5180" />
<img width="1448" height="751" alt="image" src="https://github.com/user-attachments/assets/645ff94d-3d1b-40d7-8d88-08eef36c46c7" />
