### PR TITLE
ci: add GitHub Actions deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,10 @@ permissions:
   id-token: write  # Required for OIDC token request
   contents: read
 
+concurrency:
+  group: deploy
+  cancel-in-progress: true
+
 jobs:
   deploy:
     name: Build & Deploy to S3
@@ -40,9 +44,15 @@ jobs:
 
       - name: Sync to S3
         run: |
+          # Hashed assets (dist/assets/) get a 1-year immutable cache — filenames change on every build
+          aws s3 sync dist/assets/ s3://${{ secrets.S3_BUCKET_NAME }}/assets/ \
+            --cache-control "public, max-age=31536000, immutable"
+
+          # Non-hashed files (e.g. public/ copies like favicon) must not be cached long-term
           aws s3 sync dist/ s3://${{ secrets.S3_BUCKET_NAME }} \
             --delete \
-            --cache-control "public, max-age=31536000, immutable" \
+            --cache-control "no-cache, no-store, must-revalidate" \
+            --exclude "assets/*" \
             --exclude "index.html"
 
           # index.html must not be cached — browsers need the latest entry point


### PR DESCRIPTION
Adds the S3 + CloudFront deploy workflow so pushes to `main` automatically build and deploy the frontend.

## What it does
1. Builds the Vite app (injects `VITE_API_BASE_URL` from secrets)
2. Syncs `dist/` to S3 with long-lived cache headers for assets, no-cache for `index.html`
3. Invalidates the CloudFront distribution

## Required secrets (already set)
- `GH_DEPLOY_ROLE_ARN` — OIDC role to assume
- `S3_BUCKET_NAME` — target bucket
- `CLOUDFRONT_DISTRIBUTION_ID` — distribution to invalidate
- `VITE_API_BASE_URL` — API base URL (placeholder, update after API stack deploy)